### PR TITLE
New command to flash board only

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 ## Limitation
 
 * **Can not be used in a host PC user name that contains ' ' (Space) or multi-byte characters(e.g. Japanese).**
+* **Can not be used in a host PC with welcome messages in the .bashrc.**
 
 ## How to use
 

--- a/package.json
+++ b/package.json
@@ -133,6 +133,11 @@
 				"enablement": "spresenseSdkVersionMajor"
 			},
 			{
+				"command": "spresense.onlyflash",
+				"title": "%spresense.command.onlyflash%",
+				"enablement": "spresenseSdkVersionMajor"
+			},
+			{
 				"command": "spresense.msys.path",
 				"title": "%spresense.command.msys.path%",
 				"enablement": "isWindows"
@@ -366,6 +371,11 @@
 					"when": "spresenseSdkVersionMajor",
 					"command": "spresense.flash",
 					"group": "12_SpresenseBuild@1"
+				},
+				{
+					"when": "spresenseSdkVersionMajor",
+					"command": "spresense.onlyflash",
+					"group": "12_SpresenseBuild@6"
 				},
 				{
 					"when": "spresenseSdkVersionMajor",

--- a/package.nls.ja.json
+++ b/package.nls.ja.json
@@ -15,6 +15,7 @@
 	"spresense.command.clean.kernel": "Spresense: カーネルのクリーン",
 	"spresense.command.clean.sdk": "Spresense: アプリケーションのクリーン",
 	"spresense.command.flash": "Spresense: ビルドと書き込み",
+	"spresense.command.onlyflash": "Spresense: Application flash",
 	"spresense.command.msys.path": "Spresense: MSYS2パスの設定 (Windowsのみ)",
 	"spresense.command.create.app": "Spresense: アプリケーションコマンドの作成",
 	"spresense.command.create.worker": "Spresense: ASMPワーカープログラムの作成",

--- a/package.nls.json
+++ b/package.nls.json
@@ -15,6 +15,7 @@
 	"spresense.command.clean.kernel": "Spresense: Kernel clean",
 	"spresense.command.clean.sdk": "Spresense: Application clean",
 	"spresense.command.flash": "Spresense: Build and Flash",
+	"spresense.command.onlyflash": "Spresense: Application flash",
 	"spresense.command.msys.path": "Spresense: Set MSYS install location (Windows only)",
 	"spresense.command.create.app": "Spresense: Create application command",
 	"spresense.command.create.worker": "Spresense: Create ASMP worker program",

--- a/package.nls.zh-cn.json
+++ b/package.nls.zh-cn.json
@@ -15,6 +15,7 @@
 	"spresense.command.clean.kernel": "Spresense: 清理编译内核环境",
 	"spresense.command.clean.sdk": "Spresense: 清理编译应用程序环境",
 	"spresense.command.flash": "Spresense: 编译并烧入",
+	"spresense.command.onlyflash": "Spresense: Application flash",
 	"spresense.command.msys.path": "Spresense: 设置MSYS2路径（仅Windows）",
 	"spresense.command.create.app": "Spresense: 创建应用程序命令",
 	"spresense.command.create.worker": "Spresense: 创建一个ASMP工作程序",

--- a/package.nls.zh-tw.json
+++ b/package.nls.zh-tw.json
@@ -15,6 +15,7 @@
 	"spresense.command.clean.kernel": "Spresense: 清潔內核",
 	"spresense.command.clean.sdk": "Spresense: 清潔應用",
 	"spresense.command.flash": "Spresense: 建立並燒入",
+	"spresense.command.onlyflash": "Spresense: Application flash",
 	"spresense.command.msys.path": "Spresense: 設置MSYS2路徑（僅Windows）",
 	"spresense.command.create.app": "Spresense: 創建應用程序命令",
 	"spresense.command.create.worker": "Spresense: 創建一個ASMP工作程序",

--- a/src/serial_terminal.ts
+++ b/src/serial_terminal.ts
@@ -77,6 +77,7 @@ function getEnv (platform: string) {
 function isFlashTask(taskExec: vscode.TaskExecution): boolean {
 	const flashTasks = [
 		'Build and flash',
+		'Flash application',
 		'Flash worker',
 		'Clean flash',
 		'Burn bootloader'

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -45,6 +45,7 @@ const taskBuildLabel = 'Build application';
 const taskSdkCleanLabel = 'Clean application';
 const taskkernelCleanLabel = 'Clean kernel';
 const taskFlashLabel = 'Build and flash';
+const taskOnlyFlashLabel = 'Flash application';
 const taskWorkerFlashLabel = 'Flash worker';
 const taskCleanFlashLabel = 'Clean flash';
 const taskBootFlashLabel = 'Burn bootloader';
@@ -235,6 +236,7 @@ async function sdkTaskConfig(newFolderUri: vscode.Uri, context: vscode.Extension
 	let sdkCleanTask: ConfigInterface = {};
 	let kernelCleanTask: ConfigInterface = {};
 	let flashTask: ConfigInterface = {};
+	let onlyFlashTask: ConfigInterface = {};
 	let flashWrokerTask: ConfigInterface = {};
 	let flashCleanTask: ConfigInterface = {};
 	let flashBootTask: ConfigInterface = {};
@@ -309,6 +311,20 @@ async function sdkTaskConfig(newFolderUri: vscode.Uri, context: vscode.Extension
 	flashTask['group'] = 'test';
 	flashTask['problemMatcher'] = ['$gcc'];
 
+	/* Only flash Task */
+	onlyFlashTask['label'] = taskOnlyFlashLabel;
+	onlyFlashTask['type'] = 'shell';
+	onlyFlashTask['dependsOrder'] = 'sequence',
+		onlyFlashTask['dependsOn'] = [taskWorkerFlashLabel];
+	onlyFlashTask['command'] = 'cd \"${workspaceFolder}\";${config:spresense.sdk.path}/sdk/tools/flash.sh -c ${config:spresense.serial.port} -b ${config:spresense.flashing.speed}';
+	if (isAppfolder) {
+		onlyFlashTask['command'] += ` out/*.nuttx.spk`;
+	} else {
+		onlyFlashTask['command'] += ' sdk/nuttx.spk';
+	}
+	onlyFlashTask['group'] = 'test';
+	onlyFlashTask['problemMatcher'] = ['$gcc'];
+
 	/* Flash worker Task */
 	flashWrokerTask['label'] = taskWorkerFlashLabel;
 	flashWrokerTask['type'] = 'shell';
@@ -336,6 +352,7 @@ async function sdkTaskConfig(newFolderUri: vscode.Uri, context: vscode.Extension
 		kernelCleanTask,
 		sdkCleanTask,
 		flashTask,
+		onlyFlashTask,
 		flashWrokerTask,
 		flashCleanTask,
 		flashBootTask
@@ -727,6 +744,12 @@ function registerSpresenseCommands(context: vscode.ExtensionContext) {
 	context.subscriptions.push(vscode.commands.registerCommand('spresense.flash', (selectedUri) => {
 		/* Do the flash */
 		triggerSpresenseTask(selectedUri, taskFlashLabel);
+	}));
+
+	/* Register only flash command */
+	context.subscriptions.push(vscode.commands.registerCommand('spresense.onlyflash', (selectedUri) => {
+		/* Do the flash */
+		triggerSpresenseTask(selectedUri, taskOnlyFlashLabel);
 	}));
 
 	/* Register burn bootloader command */


### PR DESCRIPTION
Hi,

I often need to trigger again the flash without build before, for example if I forget to setup the serial port, or simply because I built without flash the board to check errors.

Because "Build and flash" command takes many time to make check every folders, I added a command to just flash.

I'm not sure if it will work on your computer because contributing to VSCode extension is really hard.
